### PR TITLE
Implementation for Issue: Order By HSDS Hierarchy

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,4 +1,4 @@
-from ..lib.mapper import map, nested_map
+from ..lib.mapper import map, nested_map, get_process_order
 from ..lib.parser import parse_input_csv, parse_mapping
 # from ..lib.parser import parse_nested_mapping
 import click
@@ -53,5 +53,29 @@ if __name__ == "__main__":
     organization = nested_map(src, mapping)
     # organization = map(src, mapping)
     print(organization.model_dump_json(indent=2))
+
+    # Testing for get_process_order
+    """
+    print(get_process_order([
+        ("organization", []),
+        ("service", []),
+        ("address", []),
+        ("service_at_location", []),
+        ("location", []),
+        ("metadata", []),
+        ("service_capacity", [])
+    ]))
+
+    print(get_process_order([
+        ("langauge", []),
+        ("organization", []),
+        ("phone", []),
+        ("location", []),
+        ("program", []),
+        ("service_at_location", []),
+        ("schedule", []),
+        ("service", []),
+    ]))
+    """
 
     # main()

--- a/src/lib/relations.py
+++ b/src/lib/relations.py
@@ -1,12 +1,25 @@
 """
 DAG model of HSDS 3.1.2 entity relationships.
 Source: https://docs.openreferral.org/en/v3.1.2/hsds/schema_reference.html#
-"""
 
-# TODO: Resolve cycles:
-# organization <=> service <=> program
-# unit <=> service_capacity
-# taxonomy <=> taxonomy_term
+Notes about certain entity relationships:
+
+Service has ids that relate to Organization and Program, which causes
+a cyclic dependency.
+- RESOLUTION: Service is made to be a root entity (with no outgoing edges)
+  and an outgoing edge to Service was made for Organization and Program.
+
+Service Capacity has both an id for and field for Unit.
+- RESOLUTION: Unit now has an outgoing edge to Service Capacity as a
+  defined Unit entity must exist first.
+
+Regarding Taxonomy Term and Taxonomy entities
+- Despite the names, both can be processed independently as neither have
+  fields that directly reference each other. At most Taxonomy Term has
+  an id for a Taxonomy entity, but not a field that references an actual
+  Taxonomy.
+
+"""
 
 HSDS_RELATIONS = {
     # Core
@@ -14,10 +27,7 @@ HSDS_RELATIONS = {
         "service"
     ],
 
-    "service": [
-        "organization",
-        "program",
-    ],
+    "service": [],
     
     "location": [
         "organization"
@@ -72,7 +82,8 @@ HSDS_RELATIONS = {
     ],
     
     "program": [
-        "organization"
+        "organization",
+        "service"
     ],
     
     "required_document": [
@@ -90,11 +101,12 @@ HSDS_RELATIONS = {
         "organization"
     ],
 
-    "unit": [],
+    "unit": [
+        "service_capacity"
+    ],
     
     "service_capacity": [
         "service"
-        "unit"
     ],
 
     "attribute": [

--- a/src/lib/relations.py
+++ b/src/lib/relations.py
@@ -1,0 +1,158 @@
+"""
+DAG model of HSDS 3.1.2 entity relationships.
+Source: https://docs.openreferral.org/en/v3.1.2/hsds/schema_reference.html#
+"""
+
+# TODO: Resolve cycles:
+# organization <=> service <=> program
+# unit <=> service_capacity
+# taxonomy <=> taxonomy_term
+
+HSDS_RELATIONS = {
+    # Core
+    "organization": [
+        "service"
+    ],
+
+    "service": [
+        "organization",
+        "program",
+    ],
+    
+    "location": [
+        "organization"
+    ],
+    
+    "service_at_location": [
+        "service",
+        "location"
+    ],
+
+    # Other
+    "address": [
+        "location"
+    ],
+
+    "phone": [
+        "location",
+        "service",
+        "organization",
+        "contact",
+        "service_at_location"
+    ],
+
+    "schedule": [
+        "service",
+        "location",
+        "service_at_location"
+    ],
+
+    "service_area": [
+        "service",
+        "service_at_location"
+    ],
+
+    "language": [
+        "service",
+        "location",
+        "phone"
+    ],
+
+    "funding": [
+        "organization",
+        "service"
+    ],
+
+    "accessibility": [
+        "location"
+    ],
+
+    "cost_option": [
+        "service"
+    ],
+    
+    "program": [
+        "organization"
+    ],
+    
+    "required_document": [
+        "service"
+    ],
+    
+    "contact": [
+        "organization",
+        "service",
+        "service_at_location",
+        "location"
+    ],
+    
+    "organization_identifier": [
+        "organization"
+    ],
+
+    "unit": [],
+    
+    "service_capacity": [
+        "service"
+        "unit"
+    ],
+
+    "attribute": [
+        "organization",
+        "service",
+        "location",
+        "service_at_location",
+        "address",
+        "phone",
+        "schedule",
+        "service_area",
+        "language",
+        "funding",
+        "accessibility",
+        "cost_option",
+        "program",
+        "required_document",
+        "contact",
+        "organization_identifier",
+        "unit",
+        "url",
+        "meta_table_description"
+    ],
+    
+    "url": [
+        "organization",
+        "service"
+    ],
+    
+    "metadata": [
+        "organization",
+        "service",
+        "location",
+        "service_at_location",
+        "address",
+        "phone",
+        "schedule",
+        "service_area",
+        "language",
+        "funding",
+        "accessibility",
+        "cost_option",
+        "program",
+        "required_document",
+        "contact",
+        "organization_identifier",
+        "unit",
+        "attribute",
+        "url",
+        "meta_table_description",
+        "taxonomy"
+    ],
+    
+    "meta_table_description": [],
+
+    "taxonomy": [],
+    
+    "taxonomy_term": [
+        "attribute"
+    ]
+}


### PR DESCRIPTION
Close #9 

Adds `src/lib/relations.py` which contains a DAG representation of the HSDS 3.1.2 hierarchy as a Python dictionary object. Keys of this dictionary refer to each of the HSDS object, and their values (an array of strings) represent the immediate parents of that entity.

Adds `get_process_order()` to `src/lib/mapper.py` that returns a list of strings that denote the order in which the mapped HSDS entities should be processed, with the first index corresponding to the "lowest" entity (the first to process). Some (commented) test cases are written in `src/cli/main()` to test for correctness.