### PR TITLE
feat: identifying collection to search

### DIFF
--- a/src/lib/relationships.py
+++ b/src/lib/relationships.py
@@ -1,0 +1,37 @@
+def is_valid_id(id_value) -> bool:
+    """
+    Check if an ID value is valid (non-empty, non-null, meaningful).
+    """
+    if id_value is None:
+        return False
+    
+    id_str = str(id_value).strip()
+    
+    # Check for empty string or common "empty" values
+    if not id_str or id_str.lower() in ["null", "none", "n/a", "na"]:
+        return False
+    
+    return True
+
+
+def identify_parent_relationships(obj_dict: dict) -> list[tuple[str, str]]:
+    """
+    Given an HSDS object dictionary, identify parent relationships.
+    
+    Looks for all keys ending with '_id' (except the object's own 'id' field),
+    validates the ID values, and returns a list of parent relationships.
+    """
+    # Initialize empty list for relationships
+    relationships = []
+    
+    for key, value in obj_dict.items():
+        # Skip the object's own id field and look for parent_id fields
+        if key.endswith('_id') and key != 'id':
+            # Validate the ID value
+            if is_valid_id(value):
+                # Remove the '_id' suffix to get the parent type
+                parent_type = key[:-3]
+                # Append the parent relationship to the list
+                relationships.append((parent_type, str(value)))
+    
+    return relationships


### PR DESCRIPTION
- Built the "identify_parent_relationships" as outlined in Issue #10 
- Built a small validator function "is_valid_id", checking for common null values of ID's found in example data

Example input dictionary:
```
location_obj = {
'id': '17861867', 
'organization_id': '12345', 
'name': 'Main Office', 
'service_id': '', 
'phone_id': '14522123'}
```

Example output list:
```
[('organization', '12345'), ('phone', '14522123')]
```