### PR TITLE
UUID Generation for Entities with Missing ID Mappings

### DIFF
--- a/src/lib/mapper.py
+++ b/src/lib/mapper.py
@@ -46,7 +46,7 @@ def nested_map(data: Any, mapping_spec: Dict[str, Any], root_data=None) -> Organ
                 # This is a nested object - process recursively
                 items = list(value.items())
 
-                if not "id" in value:
+                if "id" not in value:
                     # TODO: create the proper identifier string for entity
                     uid = uuid5(NAMESPACE, "some-identifier-string")
                     items.insert(0, ("id", str(uid)))


### PR DESCRIPTION
Close #14 

Adds an `"id"` field check when building entities from a mapping schema. Specifically, in `src/lib/mapper` function `process_value()` in `nested_map()`. If the field does not exist, a UUID (v5) is generated using a globally defined UUID object and an identifier string before populating the object with data.

Currently, the UUID namespace is initialized trivially; in addition, the identifier string is fixed for every object. This will be changed when more information is available as to how we should generate these IDs (more specifically, according to OR).