### PR TITLE
CLI Outputting JSONs to Inputted Directory

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -1,23 +1,8 @@
 # from ..lib.mapper import get_process_order
 from ..lib.collections import build_collections
+from ..lib.outputs import save_objects_to_json
 import json
 import click
-import os
-
-def save_objects_to_json(objects_data, output_dir):
-    """Save each object dictionary as a separate JSON file."""
-    os.makedirs(output_dir, exist_ok=True)
-    
-    for object_type, objects_list in objects_data:
-        for obj_dict in objects_list:
-            # Extract the id from the object
-            obj_id = obj_dict.get('id')
-            if obj_id:
-                filename = f"{object_type}_{obj_id}.json"
-                filepath = os.path.join(output_dir, filename)
-                
-                with open(filepath, 'w', encoding='utf-8') as f:
-                    json.dump(obj_dict, f, indent=2, ensure_ascii=False)
 
 @click.command()
 @click.argument('data_dictionary', type=click.Path(exists=True, file_okay=False, dir_okay=True, readable=True))

--- a/src/lib/outputs.py
+++ b/src/lib/outputs.py
@@ -1,0 +1,18 @@
+import os
+import json
+
+
+def save_objects_to_json(objects_data, output_dir):
+    """Save each object dictionary as a separate JSON file."""
+    os.makedirs(output_dir, exist_ok=True)
+    
+    for object_type, objects_list in objects_data:
+        for obj_dict in objects_list:
+            # Extract the id from the object
+            obj_id = obj_dict.get('id')
+            if obj_id:
+                filename = f"{object_type}_{obj_id}.json"
+                filepath = os.path.join(output_dir, filename)
+                
+                with open(filepath, 'w', encoding='utf-8') as f:
+                    json.dump(obj_dict, f, indent=2, ensure_ascii=False)


### PR DESCRIPTION
- Built the "save_objects_to_json" function in the outputs.py folder in the lib directory, taking an object's data and a directory as inputs and saving each object dictionary as a separate JSON file in the directory
- Added an output directory argument in the command line arguments, making an "output" directory by default

Example input directory contents:

File 1: locations_location_mapping.csv
```
path,input_files_field
id,id
organization_id,organization_id
name,location_name
addresses[].address_1,address
```

File 2: locations.csv
```
id,organization_id,location_name,address
loc-001,org-001,Main Clinic,123 Health St
loc-002,org-001,South Branch,456 Wellness Ave
loc-003,org-002,Central Warehouse,789 Food Blvd
```

Example output directory contents:

File 1: location_loc-001.json
```
{
  "id": "loc-001",
  "organization_id": "org-001",
  "name": "Main Clinic",
  "addresses": [
    {
      "address_1": "123 Health St"
    }
  ]
}
```

File 2: location_loc-002.json
```
{
  "id": "loc-002",
  "organization_id": "org-001",
  "name": "South Branch",
  "addresses": [
    {
      "address_1": "456 Wellness Ave"
    }
  ]
}
```

File 3: location_loc-003.json
```
{
  "id": "loc-003",
  "organization_id": "org-002",
  "name": "Central Warehouse",
  "addresses": [
    {
      "address_1": "789 Food Blvd"
    }
  ]
}
```