### PR TITLE
Fix: Split not appearing in mapping

### DIFF
--- a/src/lib/parser.py
+++ b/src/lib/parser.py
@@ -126,7 +126,7 @@ def parse_nested_mapping(mapping_file, filename):
 
                     # Set the final value if it's the last part of the path
                     if is_last:
-                        current_level[key] = {"path": f"{filename}.{input_field}"}
+                        current_level[key] = map_obj
 
                     # Go one level deeper if it's not the last part of the path
                     else:


### PR DESCRIPTION
In parser.py, the leaf value for non-list paths was recreated instead of reusing the prepared map_obj (which contains the optional "split" key).
This change consistently uses map_obj so split is preserved.

Currently the code does this:

```python
# map_obj created with optional split
map_obj = {"path": f"{filename}.{input_field}"}
if split_val:
    map_obj["split"] = split_val

# ... inside parse_nested_mapping, Case B (non-list) when is_last is True
if is_last:
    current_level[key] = {"path": f"{filename}.{input_field}"}  # <-- loses map_obj["split"]
``` 

Now it does this:

```python
# reuse the prepared map_obj so split is preserved
if is_last:
    current_level[key] = map_obj
``` 