### PR TITLE
Remove blank fields

### DIFF
--- a/src/lib/mapper.py
+++ b/src/lib/mapper.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-from typing import Any, Callable, Dict, List
-from datetime import date
+from typing import Any, Dict, List
 from uuid import UUID, uuid5
 from glom import glom
 from .relations import HSDS_RELATIONS


### PR DESCRIPTION
Removing blank values from generated JSON objects as described in #44 

- Added `is_blank()` helper function to identify blank values:
	A value is considered 'blank' if it is:
		- `None`
		- An empty string (after stripping whitespace): `""`
		- An empty list: `[]`
		- An empty dict: `{}`
- Updated all dictionary construction points in `process_value()` to filter out blank values

Blank values are now excluded from the final JSON output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Blank/empty values are now consistently excluded from mapping outputs; path-array alignment and array expansions skip blank entries for cleaner results.
* **Breaking Changes**
  * Public mapping extension points and registration APIs have been removed; previous transform/registration interfaces are no longer available.
* **Refactor**
  * Mapping logic reorganized to filter blanks earlier and improve nested/multi-path alignment; warnings added for missing/failed filters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->