### PR TITLE
Apply custom transforms in mapper, and test.

### DIFF
--- a/data/transform_test/organizations.csv
+++ b/data/transform_test/organizations.csv
@@ -1,0 +1,2 @@
+id,name,phone,tags
+org-001,acme nonprofit,(303)617-2300,"tagC,tagA,tagB"

--- a/data/transform_test/organizations_organization_mapping.csv
+++ b/data/transform_test/organizations_organization_mapping.csv
@@ -1,0 +1,6 @@
+path,input_field,split,strip,transform
+,,,,
+id,id,,,
+name,name,,,title_case
+phone,phone,,"(;);-",format_phone
+tags[].name,tags,",",,sort_names

--- a/data/transform_test/transforms.py
+++ b/data/transform_test/transforms.py
@@ -1,0 +1,28 @@
+"""
+User-defined custom transforms for the transform_test dataset.
+Passed to the transformer via: --transforms data/transform_test/transforms.py
+"""
+
+
+def title_case(v):
+    """Capitalize the first letter of each word."""
+    return v.title()
+
+
+def format_phone(v):
+    """Format a 10-digit string as NXX-NXX-XXXX. Expects digits only (strip runs first)."""
+    return f"{v[:3]}-{v[3:6]}-{v[6:]}"
+
+
+def sort_names(lst):
+    """Sort a list of {"name": ...} objects alphabetically by name."""
+    return sorted(lst, key=lambda x: x["name"])
+
+
+transforms = {
+    "title_case": title_case,
+    "format_phone": format_phone,
+    "sort_names": sort_names,
+}
+
+hooks = {}

--- a/src/lib/mapper.py
+++ b/src/lib/mapper.py
@@ -10,7 +10,7 @@ different column/field names.
 """
 
 def nested_map(data: Any, mapping_spec: Dict[str, Any],
-               root_data=None, filter_spec=None, transreg=TransformsRegistry
+               root_data=None, filter_spec=None, transreg: TransformsRegistry=None
                ) -> dict | list | None:
     """
     Process a mapping specification and transform data using glom

--- a/src/lib/mapper.py
+++ b/src/lib/mapper.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 from typing import Any, Dict, List
 from glom import glom
 from .relations import HSDS_RELATIONS
+from .custom_transform.transforms_loader import TransformsRegistry
 
 """
 NESTED_MAP: deals with layer 1 - essentially moving from a flat spreadsheet/csv into a nested format with potentially
 different column/field names.
 """
 
-def nested_map(data: Any, mapping_spec: Dict[str, Any], root_data=None, filter_spec=None) -> dict | list | None:
+def nested_map(data: Any, mapping_spec: Dict[str, Any],
+               root_data=None, filter_spec=None, transreg=TransformsRegistry
+               ) -> dict | list | None:
     """
     Process a mapping specification and transform data using glom
     Fixed to always use the root data for path resolution - so the path doesn't get lost during 
@@ -66,6 +69,8 @@ def nested_map(data: Any, mapping_spec: Dict[str, Any], root_data=None, filter_s
                           use the path at this index over expanding all paths. 
                           Ensures child objects align with their respective parents.
         """
+
+        nonlocal transreg
         
         def is_blank(val):
             """Check if a value is considered blank/empty and should be omitted from the generated JSON object."""
@@ -113,6 +118,13 @@ def nested_map(data: Any, mapping_spec: Dict[str, Any], root_data=None, filter_s
             
             return extracted_val
 
+        def apply_transform(val, value):
+            """Apply a named custom transform from the registry if specified."""
+            if transreg is not None and "transform" in value and value["transform"]:
+                transform_fn = transreg.get_transform(value["transform"])
+                val = transform_fn(val)
+            return val
+
         # Case 1: Value is a dictionary - could be a path specification or nested object
         if isinstance(value, dict):
             # Case 1A: Dictionary contains a "path" key - this is a path specification for data extraction
@@ -130,6 +142,7 @@ def nested_map(data: Any, mapping_spec: Dict[str, Any], root_data=None, filter_s
                             val = apply_strip(val, value)
                             if val == "" or val is None:
                                 return None
+                            val = apply_transform(val, value)
                             return val
                         except Exception:
                             return None
@@ -144,6 +157,8 @@ def nested_map(data: Any, mapping_spec: Dict[str, Any], root_data=None, filter_s
                             # Convert empty strings to None for consistent filtering later
                             if val == "" or val is None:
                                 val = None
+                            else:
+                                val = apply_transform(val, value)
                             extracted_values.append(val)
                         except Exception:
                             # If path extraction fails, store None to maintain index alignment
@@ -181,15 +196,17 @@ def nested_map(data: Any, mapping_spec: Dict[str, Any], root_data=None, filter_s
                             # Split on delimiter and strip brackets and whitespace
                             parts = [part.strip() for part in extracted_val.split(split_char) if part.strip()]
                             parts = [part.strip('{}') for part in parts]
-                            
+
                             # If template is provided, wrap each part with that key (e.g., [{"name": "English"}, {"name": "Spanish"}])
                             if template:
-                                return [{template: part} for part in parts]
+                                result = [{template: part} for part in parts]
                             else:
                                 # Otherwise return flat list of strings
-                                return parts
-                    
+                                result = parts
+                            return apply_transform(result, value)
+
                     # Sub-Case 1A-2b: No split directive - return value as-is
+                    extracted_val = apply_transform(extracted_val, value)
                     return extracted_val
             # Case 1B: Dictionary does NOT contain "path" key - this is a nested object structure
             # Example: {"phones": [{"number": {"path": ...}, "name": {"path": ...}}]}

--- a/tests/test_custom_transform.py
+++ b/tests/test_custom_transform.py
@@ -1,0 +1,98 @@
+"""
+Tests for custom transform application in process_value / nested_map.
+
+Covers:
+  - Case 1A-2b: single path, no split — transform applied to scalar (title_case)
+  - Case 1A-2b: single path, strip then transform — strip runs first (format_phone)
+  - Case 1A-2a: single path, with split — transform applied to resolved list (sort_names)
+  - Selectivity: fields without a transform key pass through unchanged
+  - transreg=None: transform keys in mapping are silently ignored; strip/split still apply
+
+Run from the project root:
+    python tests/test_custom_transform.py
+"""
+
+import sys
+import os
+from pathlib import Path
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from src.lib.parser import parse_input_csv, parse_nested_mapping
+from src.lib.mapper import nested_map
+from src.lib.custom_transform.transforms_loader import TransformsRegistry
+
+DATA_DIR = Path(__file__).parent.parent / "data" / "transform_test"
+TRANSFORMS_MODULE = DATA_DIR / "transforms.py"
+
+
+def load_test_data():
+    input_rows = parse_input_csv(str(DATA_DIR / "organizations.csv"), "organizations")
+    mapping, _ = parse_nested_mapping(
+        str(DATA_DIR / "organizations_organization_mapping.csv"), "organizations"
+    )
+    return input_rows, mapping
+
+
+def test_title_case_transform():
+    """Case 1A-2b: 'acme nonprofit' → 'Acme Nonprofit' via title_case."""
+    rows, mapping = load_test_data()
+    reg = TransformsRegistry(TRANSFORMS_MODULE)
+    result = nested_map(rows[0], mapping, transreg=reg)
+    assert result["name"] == "Acme Nonprofit", f"Expected 'Acme Nonprofit', got {result['name']!r}"
+    print("PASS: title_case applied to name")
+
+
+def test_strip_then_format_phone():
+    """Case 1A-2b: strip removes ()-  first, then format_phone inserts dashes."""
+    rows, mapping = load_test_data()
+    reg = TransformsRegistry(TRANSFORMS_MODULE)
+    result = nested_map(rows[0], mapping, transreg=reg)
+    assert result["phone"] == "303-617-2300", f"Expected '303-617-2300', got {result['phone']!r}"
+    print("PASS: strip then format_phone applied to phone")
+
+
+def test_sort_names_on_split_list():
+    """Case 1A-2a: split on comma produces list, then sort_names sorts alphabetically."""
+    rows, mapping = load_test_data()
+    reg = TransformsRegistry(TRANSFORMS_MODULE)
+    result = nested_map(rows[0], mapping, transreg=reg)
+    names = [t["name"] for t in result["tags"]]
+    assert names == ["tagA", "tagB", "tagC"], f"Expected sorted tags, got {names}"
+    print("PASS: sort_names applied to split tags")
+
+
+def test_no_transform_field_passthrough():
+    """Fields with no transform key must be unaffected even when a registry is present."""
+    rows, mapping = load_test_data()
+    reg = TransformsRegistry(TRANSFORMS_MODULE)
+    result = nested_map(rows[0], mapping, transreg=reg)
+    assert result["id"] == "org-001", f"Expected 'org-001', got {result['id']!r}"
+    print("PASS: id field without transform passes through unchanged")
+
+
+def test_transreg_none_skips_transforms():
+    """With transreg=None, transform keys are ignored; strip and split still apply."""
+    rows, mapping = load_test_data()
+    result = nested_map(rows[0], mapping, transreg=None)
+
+    # title_case should NOT have run
+    assert result["name"] == "acme nonprofit", f"Expected raw name, got {result['name']!r}"
+
+    # strip still runs, but format_phone should NOT have run
+    assert result["phone"] == "3036172300", f"Expected strip-only phone, got {result['phone']!r}"
+
+    # split still runs, but sort_names should NOT have run — original CSV order preserved
+    names = [t["name"] for t in result["tags"]]
+    assert names == ["tagC", "tagA", "tagB"], f"Expected unsorted tags, got {names}"
+
+    print("PASS: transreg=None skips transforms; strip and split still apply")
+
+
+if __name__ == "__main__":
+    test_title_case_transform()
+    test_strip_then_format_phone()
+    test_sort_names_on_split_list()
+    test_no_transform_field_passthrough()
+    test_transreg_none_skips_transforms()
+    print("\nAll tests passed.")


### PR DESCRIPTION
Resolves #100

Applies custom transforms, if applicable, to mapped data in mapper.py.
Tests included as: generated csv data, sample custom transform function, and test script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for custom, named data transforms during mapping (registry-driven); includes title-case, phone-formatting, and list sorting by name. Transform application respects prior cleaning steps and can be disabled by omitting the registry.

* **Tests**
  * Added coverage for scalar transforms, strip-then-transform ordering, split-list transform/sort behavior, and registry-disabled scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->