### PR TITLE
add transforms column to mapping template generator & tests

### DIFF
--- a/src/lib/maintenance/generate_mapping/writer.py
+++ b/src/lib/maintenance/generate_mapping/writer.py
@@ -11,6 +11,7 @@ HEADER = [
     "input_files_field",
     "split",
     "strip",
+    "transform",
     "description",
     "required",
 ]
@@ -26,4 +27,4 @@ def write_mapping_template_csv(rows: Iterable[FieldSpec], out_file: str) -> None
 
         for row in rows:
             required = "true" if row.required else "false"
-            writer.writerow([row.path, "", "", "", row.description, required])
+            writer.writerow([row.path, "", "", "", "", row.description, required])

--- a/tests/fixtures/sample_mapping_template.csv
+++ b/tests/fixtures/sample_mapping_template.csv
@@ -1,13 +1,13 @@
-path,input_files_field,split,strip,description,required
-,,,,,
-id,,,,Identifier,true
-name,,,,Name,false
-details,,,,Details,true
-details.summary,,,,Summary,true
-details.notes,,,,Notes,false
-tags[],,,,Tags,true
-contacts[],,,,Contacts,false
-contacts[].email,,,,Email,false
-contacts[].phone,,,,Phone,false
-contacts[].addresses[],,,,Addresses,false
-contacts[].addresses[].line1,,,,Line 1,false
+path,input_files_field,split,strip,transform,description,required
+,,,,,,
+id,,,,,Identifier,true
+name,,,,,Name,false
+details,,,,,Details,true
+details.summary,,,,,Summary,true
+details.notes,,,,,Notes,false
+tags[],,,,,Tags,true
+contacts[],,,,,Contacts,false
+contacts[].email,,,,,Email,false
+contacts[].phone,,,,,Phone,false
+contacts[].addresses[],,,,,Addresses,false
+contacts[].addresses[].line1,,,,,Line 1,false

--- a/tests/test_generate_mapping_cli.py
+++ b/tests/test_generate_mapping_cli.py
@@ -37,8 +37,8 @@ def test_generate_mapping_writes_to_current_directory(monkeypatch, tmp_path: Pat
     out_file = tmp_path / "organization_mapping_template.csv"
     assert out_file.exists()
     contents = out_file.read_text(encoding="utf-8").splitlines()
-    assert contents[0] == "path,input_files_field,split,strip,description,required"
-    assert contents[1] == ",,,,,"
+    assert contents[0] == "path,input_files_field,split,strip,transform,description,required"
+    assert contents[1] == ",,,,,,"
 
 
 def test_generate_mapping_sanitizes_schema_name(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
resolves #108

In mapping template generator code (src/lib/maintenance/generate_mapping/writer.py):
- Added "transform" header column
- Added single corresponding empty column in all rows after header column

Updated test:
- Updated ground-truth template in tests/fixtures/sample_mapping_template.csv, which is used in test_mapping_template_generator.py (no update needed in actual test module)

Confirmed expected behavior via updated test, and manual check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced data export format structure with an additional field to improve organization and data consistency. Row-level output has been realigned to maintain proper alignment with updated field definitions, ensuring all exported records are properly structured with the new field positioned correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->