### PR TITLE
updated broken imports in test/test_custom_transform

### DIFF
--- a/tests/test_custom_transform.py
+++ b/tests/test_custom_transform.py
@@ -18,9 +18,9 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from src.lib.parser import parse_input_csv, parse_nested_mapping
-from src.lib.mapper import nested_map
-from src.lib.custom_transform.transforms_loader import TransformsRegistry
+from src.lib.transform.parser import parse_input_csv, parse_nested_mapping
+from src.lib.transform.mapper import nested_map
+from src.lib.transform.custom_transform.transforms_loader import TransformsRegistry
 
 DATA_DIR = Path(__file__).parent.parent / "data" / "transform_test"
 TRANSFORMS_MODULE = DATA_DIR / "transforms.py"


### PR DESCRIPTION
fixes #124

Test was failing after repository reorganization due to inability to import proper modules. Fixed module paths.
Test now passes per spec.