### PR TITLE
Fix API temp directory resolution for ECS runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,7 @@ Once the collections have been created, we search through each collection, linki
 # Start the FastAPI server
 uvicorn api.app:app --app-dir src --reload
 ```
+
+If you deploy in an environment where default temp directories are not writable
+(for example, some ECS task configurations), set `HSDS_TMP_DIR` to a writable
+path before starting the API.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -13,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from api.middleware import RouterLoggingMiddleware
 from api.logger import configure_logger
+from api.tempdir import get_writable_temp_dir
 from lib.transform.collections import build_collections, searching_and_assigning
 from lib.transform.outputs import save_objects_to_json
 from api.model import HealthResponse
@@ -85,8 +86,13 @@ async def transform(
     except zipfile.BadZipFile:
         raise HTTPException(status_code=422, detail="Invalid zip file")
 
+    try:
+        temp_root = get_writable_temp_dir()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
     # Unzip into a temp directory
-    with tempfile.TemporaryDirectory() as input_dir:
+    with tempfile.TemporaryDirectory(dir=temp_root, prefix="hsds-input-") as input_dir:
         with zipfile.ZipFile(io.BytesIO(content), "r") as zf:
             zf.extractall(input_dir)
 
@@ -109,7 +115,7 @@ async def transform(
         results = searching_and_assigning(results)
 
         # Write each object to JSON files in another temp dir, then zip and return
-        with tempfile.TemporaryDirectory() as output_dir:
+        with tempfile.TemporaryDirectory(dir=temp_root, prefix="hsds-output-") as output_dir:
             save_objects_to_json(results, output_dir)
             buf = io.BytesIO()
             with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as out_zip:

--- a/src/api/tempdir.py
+++ b/src/api/tempdir.py
@@ -1,0 +1,42 @@
+import os
+import tempfile
+from pathlib import Path
+
+
+def _default_temp_candidates() -> list[Path]:
+    """Return ordered fallback temp-directory candidates."""
+    return [Path(tempfile.gettempdir()), Path("/tmp"), Path("/var/tmp"), Path("/usr/tmp")]
+
+
+def _is_writable_dir(path: Path) -> bool:
+    """Create directory (if needed) and verify write access."""
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return False
+
+    try:
+        with tempfile.NamedTemporaryFile(dir=path, prefix=".hsds-write-test-", delete=True):
+            pass
+    except OSError:
+        return False
+
+    return True
+
+
+def get_writable_temp_dir(env_var: str = "HSDS_TMP_DIR") -> str:
+    """Resolve a writable temp directory for API file operations."""
+    configured = os.getenv(env_var)
+    if configured:
+        candidate_paths = [Path(configured)]
+    else:
+        candidate_paths = _default_temp_candidates()
+
+    for candidate in candidate_paths:
+        if _is_writable_dir(candidate):
+            return str(candidate)
+
+    raise RuntimeError(
+        f"No writable temporary directory available. Set {env_var} to a writable path. "
+        f"Checked: {[str(path) for path in candidate_paths]}"
+    )

--- a/tests/test_api_tempdir.py
+++ b/tests/test_api_tempdir.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+import pytest
+
+from src.api import tempdir
+
+
+def test_get_writable_temp_dir_prefers_env_var(monkeypatch, tmp_path: Path) -> None:
+    custom_temp = tmp_path / "custom-temp-root"
+    monkeypatch.setenv("HSDS_TMP_DIR", str(custom_temp))
+
+    resolved = tempdir.get_writable_temp_dir()
+
+    assert resolved == str(custom_temp)
+    assert custom_temp.exists()
+    assert custom_temp.is_dir()
+
+
+def test_get_writable_temp_dir_falls_back_to_first_writable_candidate(
+    monkeypatch, tmp_path: Path
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+
+    monkeypatch.delenv("HSDS_TMP_DIR", raising=False)
+    monkeypatch.setattr(tempdir, "_default_temp_candidates", lambda: [first, second])
+    monkeypatch.setattr(tempdir, "_is_writable_dir", lambda p: p == second)
+
+    resolved = tempdir.get_writable_temp_dir()
+
+    assert resolved == str(second)
+
+
+def test_get_writable_temp_dir_raises_when_no_candidates_writable(monkeypatch) -> None:
+    monkeypatch.delenv("HSDS_TMP_DIR", raising=False)
+    monkeypatch.setattr(tempdir, "_default_temp_candidates", lambda: [Path("/tmp/a"), Path("/tmp/b")])
+    monkeypatch.setattr(tempdir, "_is_writable_dir", lambda _p: False)
+
+    with pytest.raises(RuntimeError) as exc:
+        tempdir.get_writable_temp_dir()
+
+    assert "HSDS_TMP_DIR" in str(exc.value)


### PR DESCRIPTION
## Summary
- add a temp-directory resolver for the API that validates writable storage and supports an explicit `HSDS_TMP_DIR` override for ECS deployments
- update `/transform` to use the resolved writable temp root for both input extraction and output JSON staging, returning a clear 500 if no writable temp path is available
- add unit tests for env-var preference, fallback behavior, and failure mode, plus README guidance for setting `HSDS_TMP_DIR`

## Testing
- `pytest -q tests/test_api_tempdir.py`
- `pytest -q` *(currently fails in this environment due to pre-existing missing deps/imports: `glom` and `src.lib.parser` path in older tests)*

Closes #111