### PR TITLE
Add end-to-end verification for streaming JSON transform endpoint

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -18,6 +18,7 @@ from lib.transform.collections import build_collections, searching_and_assigning
 from lib.transform.json_collections import build_collections_from_json
 from lib.transform.outputs import save_objects_to_json
 from api.model import HealthResponse
+from api.validators import validate_no_duplicate_filenames, validate_json_transform_files
 
 
 configure_logger()
@@ -28,6 +29,9 @@ origins = [
 "http://localhost:5173",
 "https://hsds.sitblueprint.com"
 ]
+
+# Temporary upload limit. Change this later once the real production limit is decided.
+MAX_UPLOAD_SIZE_BYTES = 5 * 1024 * 1024
 
 # Adding CORS middleware
 app.add_middleware(
@@ -87,6 +91,8 @@ async def transform(
     if not zip_file.filename or not zip_file.filename.lower().endswith(".zip"):
         raise HTTPException(status_code=422, detail="Must provide a zip file")
     content = await zip_file.read()
+    if len(content) > MAX_UPLOAD_SIZE_BYTES:
+        raise HTTPException(status_code=413, detail="Uploaded zip file is too large")
     if not content:
         raise HTTPException(status_code=422, detail="Zip file is empty")
     try:
@@ -95,6 +101,7 @@ async def transform(
                 raise HTTPException(
                     status_code=422, detail="Zip file contains no files"
                 )
+            validate_no_duplicate_filenames(zf)
     except zipfile.BadZipFile:
         raise HTTPException(status_code=422, detail="Invalid zip file")
 
@@ -121,6 +128,7 @@ async def transform(
         # Run the transformer: build collections, then link parents/children
         try:
             if input_format == "json":
+                validate_json_transform_files(input_dir)
                 results = build_collections_from_json(input_dir)
             else:
                 results = build_collections(input_dir)

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -90,9 +90,20 @@ async def transform(
     # Input validation: require a non-empty .zip file
     if not zip_file.filename or not zip_file.filename.lower().endswith(".zip"):
         raise HTTPException(status_code=422, detail="Must provide a zip file")
-    content = await zip_file.read()
-    if len(content) > MAX_UPLOAD_SIZE_BYTES:
-        raise HTTPException(status_code=413, detail="Uploaded zip file is too large")
+    # reads the upload in chunks so oversized files can be rejected early
+    content_buffer = io.BytesIO()
+    total_size = 0
+
+    while chunk := await zip_file.read(1024 * 1024):
+        total_size += len(chunk)
+
+        if total_size > MAX_UPLOAD_SIZE_BYTES:
+            raise HTTPException(status_code=413, detail="Uploaded zip file is too large")
+
+        content_buffer.write(chunk)
+
+    # converts buffered chunks back into bytes for zip validation and extraction
+    content = content_buffer.getvalue()
     if not content:
         raise HTTPException(status_code=422, detail="Zip file is empty")
     try:

--- a/src/api/validators.py
+++ b/src/api/validators.py
@@ -1,0 +1,43 @@
+import zipfile
+from pathlib import Path
+
+from fastapi import HTTPException
+
+
+# helper function to check for duplicate filenames (even in subdirectories)
+def validate_no_duplicate_filenames(zf: zipfile.ZipFile) -> None:
+    seen_filenames = set()
+
+    for file_info in zf.infolist():
+        if file_info.is_dir():
+            continue
+
+        filename = Path(file_info.filename).name
+
+        if filename in seen_filenames:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Duplicate filename found in zip: {filename}",
+            )
+
+        seen_filenames.add(filename)
+
+# helper function to ensure json uploads contain required files
+def validate_json_transform_files(input_dir: str) -> None:
+    files = [p for p in Path(input_dir).rglob("*") if p.is_file()]
+
+    has_json_file = False
+    has_mapping_file = False
+
+    for file_path in files:
+        if file_path.suffix.lower() == ".json":
+            has_json_file = True
+
+        if file_path.name.lower().endswith("_mapping.csv"):
+            has_mapping_file = True
+
+    if not has_json_file:
+        raise HTTPException(status_code=422, detail="JSON input file is missing")
+
+    if not has_mapping_file:
+        raise HTTPException(status_code=422, detail="Mapping file is missing")


### PR DESCRIPTION
#119  Added end-to-end verification for the new streaming JSON transform endpoint. Covers successful ZIP responses, 413 oversized uploads, 422 errors for missing mappings / duplicate filenames / invalid JSON paths, confirms middleware does not break streamed ZIP responses, and checks the request workspace directory gets passed into the JSON builder. Existing CSV tests still pass.