### PR TITLE
Fixed split issues

### DIFF
--- a/src/lib/transform/mapper.py
+++ b/src/lib/transform/mapper.py
@@ -193,9 +193,14 @@ def nested_map(data: Any, mapping_spec: Dict[str, Any],
                     if "split" in value and value["split"]:
                         split_char = value["split"]
                         if isinstance(extracted_val, str):
-                            # Split on delimiter and strip brackets and whitespace
-                            parts = [part.strip() for part in extracted_val.split(split_char) if part.strip()]
-                            parts = [part.strip('{}') for part in parts]
+                            # Split on delimiter, clean wrappers, then filter blanks.
+                            # This prevents placeholders like "{}" from becoming
+                            # array items with empty string values.
+                            parts = []
+                            for part in extracted_val.split(split_char):
+                                cleaned = part.strip().strip('{}').strip()
+                                if cleaned:
+                                    parts.append(cleaned)
 
                             # If template is provided, wrap each part with that key (e.g., [{"name": "English"}, {"name": "Spanish"}])
                             if template:

--- a/tests/test_sanity_check.py
+++ b/tests/test_sanity_check.py
@@ -100,3 +100,16 @@ def test_sanity_check_relational():
 
     # Check Service B has no program
     assert "program" not in service_b
+
+
+def test_split_test_omits_empty_split_items():
+    collections = build_collections(str(DATA_DIR / "split_test"))
+    services = dict(collections)["service"]
+    services_by_id = {service["id"]: service for service in services}
+
+    assert "languages" not in services_by_id["131293"]
+    assert "languages" not in services_by_id["162670"]
+    assert services_by_id["236966"]["languages"] == [
+        {"name": "English"},
+        {"name": "Spanish"},
+    ]


### PR DESCRIPTION
## Summary

Fix split-cell handling so placeholder-only values like {} do not create empty array objects.

## Changes

- Clean split parts before filtering blank values in nested_map.
- Prevent outputs like languages: [{"name": ""}] when the source split cell has no real values.
- Preserve existing split behavior for valid wrapped values like {English,Spanish}.
- Add a regression test using data/split_test to cover both empty and non-empty split cases.

## Testing
- Verified data/split_test transform output in memory:
- Empty language placeholders now omit languages.
- {English,Spanish} still expands correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved split transformation handling to properly filter empty and placeholder-style values from results, ensuring cleaner data output.

* **Tests**
  * Added validation tests for split field behavior to ensure empty items are excluded and valid results are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->