### PR TITLE
Moved validation logic from /transform into /transform/stream

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -147,7 +147,6 @@ async def transform(
         # Run the transformer: build collections, then link parents/children
         try:
             if input_format == "json":
-                validate_json_transform_files(input_dir)
                 results = build_collections_from_json(input_dir)
             else:
                 results = build_collections(input_dir)
@@ -205,7 +204,8 @@ async def transform_stream(
             max_upload_bytes=MAX_MULTIPART_UPLOAD_BYTES,
         )
         validate_staged_workspace(summary)
-
+        validate_json_transform_files(str(input_dir))
+        
         try:
             results = build_collections_from_json(str(input_dir))
         except ValueError as exc:


### PR DESCRIPTION
Pretty simple fix, all I had to do is move my validation call from one endpoint to another.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted JSON validation logic across transform endpoints: removed validation from the standard `/transform` endpoint's JSON input path, while adding JSON-specific validation to the `/transform/stream` endpoint after file staging.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stevensblueprint/hsds-transformer/pull/140)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->